### PR TITLE
Fix a problem in parsing game address for custom games

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Options to pass into the `options` object:
 
 | Option | Type |Description | Default value<br>(if null/undefined or omitted) |
 | - | - | - | - |
-| players | boolean | Whether or not to fetch player names<br>Please note that fetching player names is typically a way more expensive action. | true |
+| players | boolean | Whether or not to fetch player names<br>Please note that fetching player names is typically a way more expensive action. | false |
 | timeout | positive integer | Timeout for fetching system info in general | 5000 |
 | playersTimeout | positive integer | Timeout for fetching player names, counting after system info is successfully fetched | 3000 |
 | preferredRegion | string | Preferred region in case there are multiple games in different regions with the same ID | none |

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const parseLink = function (link) {
   return {
     id: match?.[8] != null ? +match[8] : null,
     server: match?.[9] != null ? {
-      ip: match[9],
+      ip: match[10],
       port: match?.[11] != null ? +match[11] : null
     } : null
   }


### PR DESCRIPTION
there's a problem when parsing custom game link that made the `getSystemInfo()` method failed